### PR TITLE
Add depth to debug.transaction output.

### DIFF
--- a/core/vm/environment.go
+++ b/core/vm/environment.go
@@ -113,6 +113,7 @@ type StructLog struct {
 	Memory  []byte
 	Stack   []*big.Int
 	Storage map[common.Hash]common.Hash
+	Depth   int
 	Err     error
 }
 

--- a/core/vm/vm.go
+++ b/core/vm/vm.go
@@ -408,7 +408,7 @@ func (evm *EVM) log(pc uint64, op OpCode, gas, cost *big.Int, memory *Memory, st
 				return true
 			})
 		}
-		evm.env.AddStructLog(StructLog{pc, op, new(big.Int).Set(gas), cost, mem, stck, storage, err})
+		evm.env.AddStructLog(StructLog{pc, op, new(big.Int).Set(gas), cost, mem, stck, storage, evm.env.Depth(), err})
 	}
 }
 

--- a/eth/api.go
+++ b/eth/api.go
@@ -1607,6 +1607,7 @@ type structLogRes struct {
 	Op      string            `json:"op"`
 	Gas     *big.Int          `json:"gas"`
 	GasCost *big.Int          `json:"gasCost"`
+	Depth   int               `json:"depth"`
 	Error   error             `json:"error"`
 	Stack   []string          `json:"stack"`
 	Memory  map[string]string `json:"memory"`
@@ -1640,6 +1641,7 @@ func formatLogs(structLogs []vm.StructLog) []structLogRes {
 			Op:      trace.Op.String(),
 			Gas:     trace.Gas,
 			GasCost: trace.GasCost,
+			Depth:   trace.Depth,
 			Error:   trace.Err,
 			Stack:   make([]string, len(trace.Stack)),
 			Memory:  make(map[string]string),


### PR DESCRIPTION
@obscuren, while you're refactoring the debug feature for replaying transactions please consider adding this extension.

It adds the depth to each log output which makes it easier to track the status of CALL opcodes that call other contracts. The next opcode starts again with pc: 0 which makes it obvious that execution went down one level but tracking when it goes back up is not so trivial. 

Adding the depth value to each log makes it easier.
