### PR TITLE
core/vm: add depth to debug.transaction output.

### DIFF
--- a/core/vm/vm.go
+++ b/core/vm/vm.go
@@ -152,7 +152,7 @@ func (evm *EVM) Run(contract *Contract, input []byte) (ret []byte, err error) {
 	// User defer pattern to check for an error and, based on the error being nil or not, use all gas and return.
 	defer func() {
 		if err != nil {
-			evm.logger.CaptureState(pc, op, contract.Gas, cost, mem, stack, contract, err)
+			evm.logger.CaptureState(pc, op, contract.Gas, cost, mem, stack, contract, evm.env.Depth(), err)
 		}
 	}()
 
@@ -193,7 +193,7 @@ func (evm *EVM) Run(contract *Contract, input []byte) (ret []byte, err error) {
 		// Resize the memory calculated previously
 		mem.Resize(newMemSize.Uint64())
 		// Add a log message
-		evm.logger.CaptureState(pc, op, contract.Gas, cost, mem, stack, contract, nil)
+		evm.logger.CaptureState(pc, op, contract.Gas, cost, mem, stack, contract, evm.env.Depth(), nil)
 		if opPtr := evm.jumpTable[op]; opPtr.valid {
 			if opPtr.fn != nil {
 				opPtr.fn(instruction{}, &pc, evm.env, contract, mem, stack)

--- a/eth/api.go
+++ b/eth/api.go
@@ -1636,6 +1636,7 @@ type structLogRes struct {
 	Op      string            `json:"op"`
 	Gas     *big.Int          `json:"gas"`
 	GasCost *big.Int          `json:"gasCost"`
+	Depth   int               `json:"depth"`
 	Error   error             `json:"error"`
 	Stack   []string          `json:"stack"`
 	Memory  map[string]string `json:"memory"`
@@ -1669,6 +1670,7 @@ func formatLogs(structLogs []vm.StructLog) []structLogRes {
 			Op:      trace.Op.String(),
 			Gas:     trace.Gas,
 			GasCost: trace.GasCost,
+			Depth:   trace.Depth,
 			Error:   trace.Err,
 			Stack:   make([]string, len(trace.Stack)),
 			Memory:  make(map[string]string),


### PR DESCRIPTION
@obscuren, while you're refactoring the debug feature for replaying transactions please consider adding this extension.

It adds the depth to each log output which makes it easier to track the status of CALL opcodes that call other contracts. The next opcode starts again with pc: 0 which makes it obvious that execution went down one level but tracking when it goes back up is not so trivial.

Adding the depth value to each log makes it easier.
